### PR TITLE
fix(dependency): fix gulp-babel dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "conventional-changelog": "0.0.11",
     "del": "^1.1.0",
     "gulp": "^3.8.10",
-    "gulp-babel": "^5.1.0",
+    "gulp-babel": "^5.0.0",
     "gulp-bump": "^0.1.11",
     "gulp-jshint": "^1.9.0",
     "gulp-yuidoc": "^0.1.2",


### PR DESCRIPTION
Sets the dependency to the same version as the skeleton navigation app

fixes #1
