### PR TITLE
makes jspm not trying to install devDependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "format": "register",
     "directories": {
       "lib": "dist/system"
-    }
+    },
+    "dependencies": {}
   }
 }


### PR DESCRIPTION
This adds an empty `dependencies` to the jspm section of package.json. Without it, `jspm install` tries to install the `devDependencies` which obviously fails with errors like `TypeError: Install of aurelia-tools to ^0.1.3 has no registry property provided.`
