### PR TITLE
fix(test): fix running tests & add a sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.3.1",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.5",
+    "karma-jspm": "^2.0.1-beta.2",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",

--- a/test/unit/configure.spec.js
+++ b/test/unit/configure.spec.js
@@ -1,0 +1,21 @@
+import {configure} from '../../src/index';
+
+class ConfigStub {
+  globalResources(...resources) {
+    this.resources = resources;
+  }
+}
+
+describe('the Aurelia configuration', () => {
+  var mockedConfiguration;
+
+  beforeEach(() => {
+    mockedConfiguration = new ConfigStub();
+    configure(mockedConfiguration);
+  });
+
+  it('should register a global resource', () => {
+    expect(mockedConfiguration.resources).toContain('./hello-world');
+  });
+
+});


### PR DESCRIPTION
When trying to run the (empty) set of test of the plugin skeleton I ran into the following error:

```
$ gulp test
[14:59:03] Using gulpfile ~/git/skeleton-plugin/gulpfile.js
[14:59:03] Starting 'test'...
WARN [watcher]: Pattern "/home/erik/git/skeleton-plugin/jspm_packages/es6-module-loader.js" does not match any file.
WARN [watcher]: Pattern "/home/erik/git/skeleton-plugin/test/unit/**/*.js" does not match any file.
INFO [karma]: Karma v0.12.37 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
INFO [Chrome 48.0.2564 (Linux 0.0.0)]: Connected on socket 6wJVRtoW44MHuJHI-uO1 with id 56321510
Chrome 48.0.2564 (Linux 0.0.0) ERROR
  Uncaught TypeError: Incorrect configuration order. The baseURL must be configured with the first System.config call.
  at /home/erik/git/skeleton-plugin/jspm_packages/system.js:4
```

I have updated `karma-jspm` with this PR to fix this issue. Also, I've added a sample test to make Karma actually run something.
