### PR TITLE
chore(build): include build-css  gulp task and use it in  gulp build task

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -1,11 +1,11 @@
-var gulp = require('gulp');
-var runSequence = require('run-sequence');
-var to5 = require('gulp-babel');
-var paths = require('../paths');
-var compilerOptions = require('../babel-options');
-var assign = Object.assign || require('object.assign');
+let gulp = require('gulp');
+let runSequence = require('run-sequence');
+let to5 = require('gulp-babel');
+let paths = require('../paths');
+let compilerOptions = require('../babel-options');
+let assign = Object.assign || require('object.assign');
 
-gulp.task('build-html', function () {
+gulp.task('build-html', function() {
   return gulp.src(paths.html)
     .pipe(gulp.dest(paths.output + 'es2015'))
     .pipe(gulp.dest(paths.output + 'commonjs'))
@@ -13,25 +13,33 @@ gulp.task('build-html', function () {
     .pipe(gulp.dest(paths.output + 'system'));
 });
 
-gulp.task('build-es2015', function () {
+gulp.task('build-css', function() {
+  return gulp.src(paths.css)
+    .pipe(gulp.dest(paths.output + 'es2015'))
+    .pipe(gulp.dest(paths.output + 'commonjs'))
+    .pipe(gulp.dest(paths.output + 'amd'))
+    .pipe(gulp.dest(paths.output + 'system'));
+});
+
+gulp.task('build-es2015', function() {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.es2015())))
     .pipe(gulp.dest(paths.output + 'es2015'));
 });
 
-gulp.task('build-commonjs', function () {
+gulp.task('build-commonjs', function() {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.commonjs())))
     .pipe(gulp.dest(paths.output + 'commonjs'));
 });
 
-gulp.task('build-amd', function () {
+gulp.task('build-amd', function() {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.amd())))
     .pipe(gulp.dest(paths.output + 'amd'));
 });
 
-gulp.task('build-system', function () {
+gulp.task('build-system', function() {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.system())))
     .pipe(gulp.dest(paths.output + 'system'));
@@ -40,7 +48,7 @@ gulp.task('build-system', function () {
 gulp.task('build', function(callback) {
   return runSequence(
     'clean',
-    ['build-html', 'build-es2015', 'build-commonjs', 'build-amd', 'build-system'],
+    ['build-html', 'build-css', 'build-es2015', 'build-commonjs', 'build-amd', 'build-system'],
     callback
   );
 });


### PR DESCRIPTION
There was no build-css tasks.
Now it's there :)
